### PR TITLE
lib: change containerenv path to be absolute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build
         run: make test-bin-archive
       - name: Upload binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bootc.tar.zst
           path: target/bootc.tar.zst
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Download
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: bootc.tar.zst
       - name: Install
@@ -90,7 +90,7 @@ jobs:
     container: quay.io/fedora/fedora-coreos:testing-devel
     steps:
       - name: Download
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: bootc.tar.zst
       - name: Install
@@ -103,14 +103,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: bootc.tar.zst
       - name: Install
         run: tar -xvf bootc.tar.zst
       - name: Update host skopeo
         run: |
-          echo 'deb http://cz.archive.ubuntu.com/ubuntu lunar main universe' | sudo tee -a /etc/apt/sources.list 
+          echo 'deb http://cz.archive.ubuntu.com/ubuntu lunar main universe' | sudo tee -a /etc/apt/sources.list
           sudo apt update
           sudo apt upgrade skopeo
       - name: Integration tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,19 @@
 
 In order to build `bootc` you will need the following dependencies.
 
-Fedora: 
-```
-sudo dnf install ostree-libs ostree-devel
+Fedora:
+
+```bash
+sudo dnf install clippy openssl-devel ostree-devel ostree-libs rustfmt
 ```
 
 # Pre flight checks
 
-Makes sure you commented your code additions, then run 
-```
+Make sure you commented your code additions, then run
+
+```bash
 cargo fmt
 cargo clippy
 ```
-Make sure to apply any relevant suggestions. 
 
+Make sure to apply any relevant suggestions.

--- a/docs/bootc-images.md
+++ b/docs/bootc-images.md
@@ -5,12 +5,15 @@ nav_order: 2
 # "bootc compatible" images
 
 At the current time, it does not work to just do:
-```
+
+```Dockerfile
 FROM fedora
 RUN dnf -y install kernel
 ```
+
 or
-```
+
+```Dockerfile
 FROM debian
 RUN apt install kernel
 ```
@@ -30,29 +33,42 @@ for generating base images currently requires running
 through ostree tooling to generate an "ostree commit"
 which has some special formatting in the base image.
 
+The two most common ways to do this are to either:
+
+  1. compose a compatible OCI image directly via [`rpm-ostree compose image`](https://coreos.github.io/rpm-ostree/container/#creating-base-images)
+  1. encapsulate an ostree commit using `rpm-ostree compose container-encapsulate`
+
+The first method is most direct, as it streamlines the process of
+creating a base image and writing to a registry. The second method
+may be preferable if you already have a build process that produces `ostree`
+commits as an output (e.g. using [osbuild](https://www.osbuild.org/guides/image-builder-on-premises/building-ostree-images.html)
+to produce `ostree` commit artifacts.)
+
+The requirement for both methods is that your initial treefile/manifest
+**MUST** include the `bootc` package in list of packages included in your compose.
+
 However, the ostree usage is an implementation detail
 and the requirement on this will be lifted in the future.
 
-For example, the [rpm-ostree compose image](https://coreos.github.io/rpm-ostree/container/#creating-base-images)
-tooling currently streamlines creating base images, operating just
-on a declarative input and writing to a registry.
-
 # Deriving from existing base images
 
-However, it's important to emphasize that from one
+It's important to emphasize that from one
 of these specially-formatted base images, every
 tool and technique for container building applies!
 In other words it will Just Work to do
-```
+
+```Dockerfile
 FROM <bootc base image>
-RUN dnf -y install foo && dnf clean all 
+RUN dnf -y install foo && dnf clean all
 ```
+
+You can then use `podman build`, `buildah`, `docker build`, or any other container
+build tool to produce your customized image. The only requirement is that the
+container build tool supports producing OCI container images.
 
 ## Using the `ostree container commit` command
 
 As an opt-in optimization today, you can also add `ostree container commit`
-as part of your `RUN` invocations.   This will perform early detection
+as part of your `RUN` invocations. This will perform early detection
 of some incompatibilities but is not a strict requirement today and will not be
 in the future.
-
-

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,42 @@
+---
+nav_order: 4
+---
+
+# Frequently Asked Questions
+
+## How do users include their own packages/binaries in a custom "bootc compatible" container?
+
+The "bootc compatible" containers are OCI container images, so you can customize them in the same way you build containers today.
+
+For example, using your own yum/dnf repo in a Dockerfile:
+
+```Dockerfile
+FROM quay.io/redhat/rhel-base:10
+COPY custom.repo /etc/yum.repos.d/
+RUN dnf -y install custom-rpm & \
+    dnf clean all && \
+    ostree container commit
+```
+
+Or using multi-stage builds in your Dockerfile:
+
+```Dockerfile
+# Build a small Go program
+FROM registry.access.redhat.com/ubi8/ubi:latest as builder
+WORKDIR /build
+COPY . .
+RUN yum -y install go-toolset
+RUN go build hello-world.go
+
+FROM quay.io/redhat/rhel-base:10
+COPY --from=builder /build/hello-world /usr/bin
+RUN ostree container commit
+```
+
+You can find more examples at the [centos-boot-layered repo](https://github.com/CentOS/centos-boot-layered) repo or the [CoreOS layering-examples repo](https://github.com/coreos/layering-examples).
+
+## How does the use of OCI artifacts intersect with this effort?
+
+The "bootc compatible" images are OCI container images; they do not rely on the [OCI artifact specification](https://github.com/opencontainers/image-spec/blob/main/artifacts-guidance.md) or [OCI referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#enabling-the-referrers-api).
+
+It is foreseeable that users will need to produce "traditional" disk images (i.e. raw disk images, qcow2 disk images, Amazon AMIs, etc.) from the "bootc compatible" container images using additional tools. Therefore, it is reasonable that some users may want to encapsulate those disk images as an OCI artifact for storage and distribution. However, it is not a goal to use `bootc` to produce these "traditional" disk images nor to facilitate the encapsulation of those disk images as OCI artifacts.

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -447,7 +447,7 @@ async fn edit(opts: EditOpts) -> Result<()> {
     let (booted_deployment, _deployments, host) =
         crate::status::get_status_require_booted(sysroot)?;
     let new_host: Host = if let Some(filename) = opts.filename {
-        let mut r = std::io::BufReader::new(std::fs::File::open(&filename)?);
+        let mut r = std::io::BufReader::new(std::fs::File::open(filename)?);
         serde_yaml::from_reader(&mut r)?
     } else {
         let tmpf = tempfile::NamedTempFile::new()?;

--- a/lib/src/containerenv.rs
+++ b/lib/src/containerenv.rs
@@ -7,6 +7,7 @@ use cap_std_ext::cap_std::fs::Dir;
 use cap_std_ext::prelude::CapStdExtDirExt;
 use fn_error_context::context;
 
+/// Path is relative to container rootfs (assumed to be /)
 const PATH: &str = "run/.containerenv";
 
 #[derive(Debug, Default)]
@@ -25,7 +26,9 @@ pub(crate) fn get_container_execution_info(rootfs: &Dir) -> Result<ContainerExec
     let f = match rootfs.open_optional(PATH)? {
         Some(f) => BufReader::new(f),
         None => {
-            anyhow::bail!("This command must be executed inside a podman container (missing {PATH}")
+            anyhow::bail!(
+                "This command must be executed inside a podman container (missing /{PATH})"
+            )
         }
     };
     let mut r = ContainerExecutionInfo::default();

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -791,7 +791,7 @@ async fn verify_target_fetch(imgref: &ostree_container::OstreeImageReference) ->
 
     tracing::trace!("Verifying fetch for {imgref}");
     let mut imp =
-        ostree_container::store::ImageImporter::new(&tmprepo, imgref, Default::default()).await?;
+        ostree_container::store::ImageImporter::new(tmprepo, imgref, Default::default()).await?;
     use ostree_container::store::PrepareResult;
     let prep = match imp.prepare().await? {
         // SAFETY: It's impossible that the image was already fetched into this newly created temporary repository


### PR DESCRIPTION
In the context of how `bootc` is intented to run (i.e. from a container), I believe it is safe to assume that the `.containerenv` file inside the running continer will always be at `/run`, so add the leading `/` to the path.